### PR TITLE
Update dApps catalog

### DIFF
--- a/docs/oev-searchers/in-depth/index.md
+++ b/docs/oev-searchers/in-depth/index.md
@@ -48,6 +48,7 @@ extraction.
 | [INIT Capital](https://app.init.capital/?chain=81457)                                               | Blast    |
 | [Orbit Protocol](https://orbitlending.io/)                                                          | Blast    |
 | [Silo Finance RDNT market](https://v1.silo.finance/silo/0x19d3F8D09773065867e9fD11716229e73481c55A) | Ethereum |
+| [TakoTako](https://www.takotako.xyz/)                                                               | Taiko    |
 
 ## From MEV searching
 

--- a/docs/oev-searchers/in-depth/index.md
+++ b/docs/oev-searchers/in-depth/index.md
@@ -22,15 +22,16 @@ Api3 feeds are used across many dApps, but not all are suitable for OEV searchin
 
 The following table includes dApps which integrated OEV proxies and are good candidates for OEV searching. The chain and dApp alias define are unique for every market and are required when implementing searcher bots.
 
-| dApp                                                 | Chain    | dApp alias       |
-| ---------------------------------------------------- | -------- | ---------------- |
-| [dTRINITY](https://dtrinity.org/)                    | Fraxtal  | `dtrinity`       |
-| [INIT Capital](https://app.init.capital/?chain=5000) | Mantle   | `init`           |
-| [Lendle](https://lendle.xyz/)                        | Mantle   | `lendle`         |
-| [MachFi](https://www.machfi.xyz/)                    | Sonic    | `mach-finance`   |
-| [Moonwell](https://moonwell.fi/)                     | Moonbeam | `moonwell`       |
-| [Vicuna Finance](https://vicunafinance.com/)         | Sonic    | `vicuna-finance` |
-| [Yei Finance](https://www.yei.finance/)              | Sei      | `yei`            |
+| dApp                                                 | Chain          | dApp alias       |
+| ---------------------------------------------------- | -------------- | ---------------- |
+| [dTRINITY](https://dtrinity.org/)                    | Fraxtal, Sonic | `dtrinity`       |
+| [INIT Capital](https://app.init.capital/?chain=5000) | Mantle         | `init`           |
+| [Lendle](https://lendle.xyz/)                        | Mantle         | `lendle`         |
+| [MachFi](https://www.machfi.xyz/)                    | Sonic          | `mach-finance`   |
+| [Moonwell](https://moonwell.fi/)                     | Moonbeam       | `moonwell`       |
+| [Stout](https://stout.fi/)                           | Sonic          | `stout`          |
+| [Stability](https://stability.market/)               | Sonic          | `vicuna-finance` |
+| [Yei Finance](https://www.yei.finance/)              | Sei            | `yei`            |
 
 ### Legacy integrations
 

--- a/libs/link-validator.js
+++ b/libs/link-validator.js
@@ -165,8 +165,6 @@ async function testLink(url, filePath, ignoreTimeout) {
 }
 
 async function run(task) {
-  let passed = 0;
-  let failed = 0;
   console.log('Checking (' + task + ')', Object.keys(linksObj).length),
     'links.';
   for (var key in linksObj) {
@@ -178,6 +176,8 @@ async function run(task) {
         totalPassedCnt++;
       }
     }
+
+    await new Promise((r) => setTimeout(r, 1000));
   }
   console.log('\n');
 }
@@ -185,7 +185,7 @@ async function run(task) {
 /**
  * LOAD LINKS
  */
-async function loadLinks() {
+function loadLinks() {
   const paths = walkSync(distDir);
   const root = distDir.split('./docs/.vitepress/dist')[1];
   for (let i = 0; i < paths.length; i++) {
@@ -242,7 +242,7 @@ async function printFailures() {
 
 async function start() {
   linksObj = {};
-  await loadLinks();
+  loadLinks();
   await run('links');
   await printFailures();
 }


### PR DESCRIPTION
Relates to https://github.com/api3dao/api3-docs/issues/190

## Changes

1. Mentions Stout being supported by OEV Auctioneer and suitable for searching
2. Mentions dTRINITY of Sonic being supported by OEV Auctioneer and suitable for searching
3. Changes `Vicuna` to `Stability`, but still preserves the `vicuna-finance` dApp alias, because they are still using the old proxies (and will migrate later).