### PR TITLE
Remove OEV extended explorer link

### DIFF
--- a/docs/oev-searchers/in-depth/oev-network/index.md
+++ b/docs/oev-searchers/in-depth/oev-network/index.md
@@ -43,16 +43,6 @@ The OEV Network can be added as a custom network to any EVM compatible wallet.
 | Block Explorer URL | https://oev.explorer.api3.org/ |
 | Bridge URL         | https://oev.bridge.api3.org/   |
 
-::: info 💡 Tip
-
-Apart from the official bridge, Api3 hosts an extended version available at https://oev-explorer-extended.api3.org/. This is a fork of the explorer with small additions for relevant to OEV.
-
-For example, when browsing logs for [this transaction](https://oev-explorer-extended.api3.org/tx/0x2bbe268d6f2c837af9c842158183fdb5cce641bb35c7a3b0de1af06112371051?tab=logs), the extended explorer shows decoded OEV details for users' convenience.
-
-![OEV extended explorer](./oev-extended-explorer.png)
-
-:::
-
 ## Properties
 
 Here are some of the key properties of the OEV Network:


### PR DESCRIPTION
We decided to wind down the extended OEV explorer due to ongoing maintenance time usage and also replacement functionality in the OEV dashboard scheduled to be built.

Relates to https://github.com/api3dao/oev-dashboard/issues/746