### PR TITLE
Fix renovate package rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,6 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["@api3/*"],
-      "groupName": "api3",
-      "minimumReleaseAge": "2 days"
-    },
-    {
       "matchDepTypes": ["packageManager"],
       "matchPackageNames": ["pnpm"],
       "extends": ["schedule:quarterly"]
@@ -34,6 +29,12 @@
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 4am on Monday"],
       "groupName": "non-major-dependencies"
+    },
+    {
+      "matchPackageNames": ["@api3/*"],
+      "schedule": ["before 6pm"],
+      "minimumReleaseAge": "2 days",
+      "groupName": "api3"
     }
   ],
   "rangeStrategy": "bump",
@@ -41,6 +42,7 @@
     "enabled": false
   },
   "reviewers": ["Siegrift"],
+  "internalChecksFilter": "strict",
   "minimumReleaseAge": "5 days",
   "dependencyDashboard": false
 }


### PR DESCRIPTION
From the docs:

> packageRules is a collection of rules, that are all evaluated. If multiple rules match a dependency, configurations from matching rules will be merged together. The order of rules matters, because later rules may override configuration options from earlier ones, if they both specify the same option.
https://docs.renovatebot.com/configuration-options/#packagerules

The broader "non-major-devDependencies" and "non-major-dependencies" groups were effectively overriding the "api3" group. 