### PR TITLE
Stop node-related renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:base"],
   "packageRules": [
     {
-      "matchPackageNames": ["node"],
+      "matchPackageNames": ["node", "actions/node-versions", "@types/node"],
       "enabled": false
     },
     {


### PR DESCRIPTION
PRs like https://github.com/api3dao/api3-docs/pull/256 are really annoying, so this will stop them (confirmed in https://github.com/api3dao/dao-docs/pull/81)