### PR TITLE
Update Airnode address description

### DIFF
--- a/docs/dapps/integration/index.md
+++ b/docs/dapps/integration/index.md
@@ -187,10 +187,10 @@ If you want to see what happens under the hood, you can click "Verified," which 
   "currentTimestamp": "1740583493",
   "deploymentTimestamp": "1739870993",
   "configHash": "0xbd159fb423d5eef7abd7947cf8ad1731f0c60cc2e093877837988907580539c9",
-  "certifiedAirnodes": ["0x6b56E47DccFbC82D63Df3da417d26e8B1B877f0f"]
+  "certifiedAirnodes": ["0xf19572194e6aD6d84666906D5287e2c9427655C2"]
 }
 ```
 
 We know that CoinGecko is a reputable API provider, they own the `coingecko.com` domain, and this response comes from that domain.
-`certifiedAirnodes` is the list of addresses of the accounts that CoinGecko uses to sign its data (only `0x6b56E47DccFbC82D63Df3da417d26e8B1B877f0f` in this case), and the Market frontend confirms that the respective data feed is configured to use data signed by one of these certified accounts.
-Finally, all recent data points signed by CoinGecko can be fetched directly from them through https://signed-api.coingecko.com/public/0x6b56E47DccFbC82D63Df3da417d26e8B1B877f0f.
+`certifiedAirnodes` is the list of addresses of the accounts that CoinGecko uses to sign its data (only `0xf19572194e6aD6d84666906D5287e2c9427655C2` in this case), and the Market frontend confirms that the respective data feed is configured to use data signed by one of these certified accounts.
+Finally, all recent data points signed by CoinGecko can be fetched directly from them through https://signed-api.coingecko.com/public/0xf19572194e6aD6d84666906D5287e2c9427655C2.

--- a/docs/oev-searchers/glossary.md
+++ b/docs/oev-searchers/glossary.md
@@ -34,9 +34,8 @@ schema.
 
 ### Airnode address
 
-All [API providers](#api-provider) [sign their data](#signed-data) with an EOA
-wallet. The address of this wallet is announced by the respective API provider
-in the DNS records of the base URL of their API.
+All [API providers](#api-provider) [sign their data](#signed-data) with an EOA wallet. The authorized signing address is published at the provider’s signed-api subdomain and announced via the certifiedAirnodes field in the returned JSON.  
+For example, CoinGecko publishes its certified signing address at https://signed-api.coingecko.com/.
 
 ### Airnode feed
 


### PR DESCRIPTION
We no longer use DNS for verification. Instead, providers deploy their own signed API under the `signed-api.` subdomain, which exposes the Airnode address as `certifiedAirnodes`.

We also recently rotated the mnemonic for CoinGecko. As a result, the Airnode address previously shown in the examples is deprecated and has been updated accordingly.