### PR TITLE
Update base feed delay to 15s

### DIFF
--- a/docs/dapps/integration/security-considerations.md
+++ b/docs/dapps/integration/security-considerations.md
@@ -95,7 +95,7 @@ Similarly, our OEV implementation uses this mechanism, ensuring OEV updates cont
 [OEV](/oev/) updates provide identical guarantees to regular updates—they are on-chain aggregations of API provider-signed data—so they introduce no additional [data correctness](#data-correctness) risk.
 The OEV updates allows winners to frontrun updates of an artificially delayed base feed, a tradeoff designed to benefit the dApp.
 
-dApps using our system will experience a 0–20 second delay in their data feed.
+dApps using our system will experience a 0–15 second delay in their data feed.
 While this delay concerns some users, we can evaluate its impact through a simple framework:
 Consider a dApp that generates `X1` revenue with its current oracle solution.
 Using Api3 data feeds would generate `X2` revenue (potentially lower than `X1` due to the delay) plus `Y` in OEV Rewards.


### PR DESCRIPTION
We cut the Signed API base feed delay from 20s to 15s in July and this was the only place in the docs quoting the old number.